### PR TITLE
Remove unnecessary semicolon in example Python code

### DIFF
--- a/tutorials/testing/python/graph_alist.py
+++ b/tutorials/testing/python/graph_alist.py
@@ -7,7 +7,7 @@ import sys
 def main():
 
     # create the Bridges object, set credentials
-    bridges = Bridges(YOUR_ASSSIGNMENT_NUMBER, "YOUR_USER_ID", "YOUR_API_KEY");
+    bridges = Bridges(YOUR_ASSSIGNMENT_NUMBER, "YOUR_USER_ID", "YOUR_API_KEY")
 
     # title, description
     bridges.set_title("A Simple Graph (Adjacency List) Example using IMDB Actor/Movie Data")

--- a/tutorials/testing/python/graph_alist.py.html
+++ b/tutorials/testing/python/graph_alist.py.html
@@ -8,7 +8,7 @@
 <span class="Statement">def</span> <span class="Identifier">main</span>():
 
     <span class="Comment"># create the Bridges object, set credentials</span>
-    bridges = Bridges(YOUR_ASSSIGNMENT_NUMBER, <span class="Constant">&quot;</span><span class="Constant">YOUR_USER_ID</span><span class="Constant">&quot;</span>, <span class="Constant">&quot;</span><span class="Constant">YOUR_API_KEY</span><span class="Constant">&quot;</span>);
+    bridges = Bridges(YOUR_ASSSIGNMENT_NUMBER, <span class="Constant">&quot;</span><span class="Constant">YOUR_USER_ID</span><span class="Constant">&quot;</span>, <span class="Constant">&quot;</span><span class="Constant">YOUR_API_KEY</span><span class="Constant">&quot;</span>)
 
     <span class="Comment"># title, description</span>
     bridges.set_title(<span class="Constant">&quot;</span><span class="Constant">A Simple Graph (Adjacency List) Example using IMDB Actor/Movie Data</span><span class="Constant">&quot;</span>)


### PR DESCRIPTION
Extremely minor, but semicolons are not necessary at the end of a line of Python code.